### PR TITLE
Fix: Add setuptools package discovery for uvx compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 name = "mcp-extended-gitlab"
 version = "0.1.0"
 description = "Comprehensive MCP server for GitLab REST API"
+readme = "README.md"
 authors = [
     {name = "MCP Extended GitLab", email = "example@example.com"}
 ]
@@ -24,6 +25,10 @@ dev = [
 [build-system]
 requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["mcp_extended_gitlab*"]
 
 [tool.black]
 line-length = 88


### PR DESCRIPTION
## Summary
- Added setuptools package discovery configuration to enable uvx installation from git
- Fixed package installation issues when using `uvx --from git+...`
- Added readme field to project metadata

## Problem
When trying to use uvx with the MCP server directly from the git repository, the installation would fail because setuptools couldn't find the packages without explicit configuration.

## Solution
Added `[tool.setuptools.packages.find]` section to `pyproject.toml` to explicitly tell setuptools where to find the packages.

## Test Plan
- [ ] Test installation with: `uvx --from git+https://github.com/Xopoko/mcp-extended-gitlab.git mcp-extended-gitlab --help`
- [ ] Verify MCP server works with Claude Desktop using the uvx configuration
- [ ] Ensure regular pip installation still works: `pip install -e .`

## Example Configuration
Now users can use this MCP server with uvx in their Claude Desktop config:

```json
{
  "gitlab-extended": {
    "command": "uvx",
    "args": [
      "--from",
      "git+https://github.com/Xopoko/mcp-extended-gitlab.git",
      "mcp-extended-gitlab"
    ],
    "env": {
      "GITLAB_PRIVATE_TOKEN": "glpat-**********"
    }
  }
}
```

🤖 Generated with [Claude Code](https://claude.ai/code)