### PR TITLE
Fix: Wrap list responses for FastMCP compatibility

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,13 @@ export GITLAB_ENABLED_TOOLS='["list_projects","get_project","list_issues"]'
 
 This is an MCP (Model Context Protocol) server providing 478+ tools for GitLab's REST API, built with FastMCP. The codebase follows a domain-driven design.
 
+### Response Format
+
+To ensure FastMCP compatibility, the client automatically wraps list responses:
+- **List operations**: Arrays are wrapped as `{"items": [...], "count": n}`
+- **Single object operations**: Passed through unchanged
+- This is handled in `utils.py:wrap_response()` and applied in `client.py`
+
 ### Tool Filtering
 
 Due to the large number of tools (478+), the server supports filtering to reduce Claude's context usage:

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ MCP Extended GitLab enables AI agents to interact with GitLab programmatically t
 - **⚡ Async Operations**: High-performance async HTTP client for efficient API calls
 - **🛡️ Error Handling**: Comprehensive error handling with detailed error messages
 - **📝 Type Safety**: Full Pydantic models for request/response validation
+- **📊 List Response Wrapping**: Automatic wrapping of array responses for FastMCP compatibility
 - **🎯 Domain-Driven Architecture**: Tools organized into focused modules across 8 logical domains
 - **📦 Modular Design**: Easy to maintain, extend, and understand codebase structure
 
@@ -248,6 +249,34 @@ Use the get_pipeline tool with project_id="my-app", pipeline_id="456"
 "Show container registry images for my-app"
 "Get DORA metrics for the last 30 days"
 ```
+
+## 📄 Response Format
+
+All tools in MCP Extended GitLab return responses in a consistent format to ensure compatibility with FastMCP:
+
+### List Operations
+When a GitLab API endpoint returns an array (e.g., list of projects, issues, etc.), the response is automatically wrapped in a dictionary:
+
+```json
+{
+  "items": [...],  // The original array from GitLab API
+  "count": 5       // Number of items in the array
+}
+```
+
+### Single Object Operations
+When a GitLab API endpoint returns a single object (e.g., get project, get issue, etc.), the response is passed through unchanged:
+
+```json
+{
+  "id": 123,
+  "name": "my-project",
+  "description": "Project description",
+  // ... other GitLab API fields
+}
+```
+
+This automatic wrapping ensures compatibility with FastMCP's structured content requirements while preserving all original GitLab API data.
 
 ## 📊 API Coverage Overview
 

--- a/examples/claude_config_windows.json
+++ b/examples/claude_config_windows.json
@@ -1,0 +1,30 @@
+{
+  "gitlab-extended": {
+    "command": "uvx",
+    "args": [
+      "--from",
+      "git+https://github.com/Xopoko/mcp-extended-gitlab.git",
+      "mcp-extended-gitlab"
+    ],
+    "env": {
+      "GITLAB_PRIVATE_TOKEN": "YOUR_GITLAB_TOKEN",
+      "GITLAB_BASE_URL": "https://gitlab.example.com/api/v4",
+      "PYTHONIOENCODING": "utf-8",
+      "PYTHONUTF8": "1"
+    }
+  },
+  "gitlab-extended-minimal": {
+    "command": "uvx",
+    "args": [
+      "--from",
+      "git+https://github.com/Xopoko/mcp-extended-gitlab.git",
+      "mcp-extended-gitlab"
+    ],
+    "env": {
+      "GITLAB_PRIVATE_TOKEN": "glpat-**********",
+      "GITLAB_ENABLED_TOOLS": "minimal",
+      "PYTHONIOENCODING": "utf-8"
+    }
+  },
+  "_comment": "Windows users must include PYTHONIOENCODING=utf-8 to prevent Unicode errors"
+}

--- a/mcp_extended_gitlab/client.py
+++ b/mcp_extended_gitlab/client.py
@@ -7,6 +7,8 @@ from urllib.parse import urljoin
 import httpx
 from pydantic import BaseModel
 
+from .utils import wrap_response
+
 
 class GitLabConfig(BaseModel):
     """GitLab configuration model."""
@@ -78,7 +80,9 @@ class GitLabClient:
             # Handle different response types
             content_type = response.headers.get("content-type", "")
             if "application/json" in content_type:
-                return response.json()
+                data = response.json()
+                # Wrap list responses in a dictionary for FastMCP compatibility
+                return wrap_response(data)
             else:
                 return {"content": response.text, "status_code": response.status_code}
                 

--- a/mcp_extended_gitlab/utils.py
+++ b/mcp_extended_gitlab/utils.py
@@ -1,0 +1,21 @@
+"""Utility functions for MCP Extended GitLab."""
+
+from typing import Any, Dict, List, Union
+
+
+def wrap_response(data: Union[Dict[str, Any], List[Any]]) -> Dict[str, Any]:
+    """
+    Wrap API responses to ensure they are always dictionaries.
+    
+    FastMCP requires structured_content to be a dict or None.
+    When GitLab API returns a list, we wrap it in a dictionary.
+    
+    Args:
+        data: The response data from GitLab API
+        
+    Returns:
+        Dictionary containing the response data
+    """
+    if isinstance(data, list):
+        return {"items": data, "count": len(data)}
+    return data


### PR DESCRIPTION
## Summary

This PR fixes the `structured_content must be a dict or None. Got list` error that occurs when MCP tools return arrays from GitLab API list endpoints.

## Problem

FastMCP requires that `structured_content` be a dictionary or None, but GitLab's REST API returns arrays for list operations (e.g., `list_projects`, `list_issues`, `list_repository_commits`). This mismatch was causing the MCP server to return errors instead of the expected data.

## Solution

- Created a `wrap_response()` utility function that automatically wraps array responses in a dictionary format: `{"items": [...], "count": n}`
- Integrated the wrapper into `GitLabClient` to handle all JSON responses
- Single object responses (dicts) are passed through unchanged
- Added comprehensive documentation about the response format

## Changes

1. **New file: `mcp_extended_gitlab/utils.py`**
   - Added `wrap_response()` function to handle array wrapping

2. **Modified: `mcp_extended_gitlab/client.py`**
   - Import and apply `wrap_response()` to all JSON responses

3. **Documentation updates:**
   - Added "Response Format" section to README.md
   - Updated CLAUDE.md with architecture details
   - Added Windows configuration example

## Testing

- Tested the wrapper function with various input types (lists, dicts, empty lists)
- All list-returning tools should now work correctly without errors
- Single object tools continue to work as before

## Impact

This fix enables all 478+ GitLab tools to work correctly with FastMCP, particularly the numerous list operations that were previously failing.

🤖 Generated with [Claude Code](https://claude.ai/code)